### PR TITLE
Raise imap_pwd length limit

### DIFF
--- a/SQL/mysql.initial.sql
+++ b/SQL/mysql.initial.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS `identy_switch`(
     `label` VARCHAR(32),
     `flags` INT NOT NULL DEFAULT 0,
     `imap_user` VARCHAR(64),
-    `imap_pwd` VARCHAR(64),
+    `imap_pwd` VARCHAR(128),
     `imap_host` VARCHAR(64),
     `imap_port` SMALLINT DEFAULT 0,
     `imap_delim` CHAR(1),

--- a/SQL/postgres.initial.sql
+++ b/SQL/postgres.initial.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS identy_switch(
     label VARCHAR(32),
     flags INTEGER NOT NULL DEFAULT 0,
     imap_user VARCHAR(64),
-    imap_pwd VARCHAR(64),
+    imap_pwd VARCHAR(128),
     imap_host VARCHAR(64),
     imap_port SMALLINT DEFAULT 0,
     imap_delim CHAR(1),


### PR DESCRIPTION
When installing this plugin and trying to add an email account, I ran into the following error by Postgres:
```
ERROR:  value too long for type character varying(64)
```

Therefore, I suggest changing the type of `imap_pwd` to at least 128 (that the max in my password manager).
An alternative would be to remove the limit entirely.

Best regards