### PR TITLE
Fix INSTALL_PATH hack

### DIFF
--- a/identy_switch_newmails.php
+++ b/identy_switch_newmails.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 // Include environment
 if (!defined('INSTALL_PATH'))
 	define('INSTALL_PATH', strpos($_SERVER['DOCUMENT_ROOT'], 'public_html') ?
-		   realpath(__DIR__.'/..').'/' : $_SERVER['DOCUMENT_ROOT'].'/');
+		   realpath(__DIR__.'/../..').'/' : $_SERVER['DOCUMENT_ROOT'].'/');
 require_once INSTALL_PATH.'program/include/iniset.php';
 require_once INSTALL_PATH.'plugins/identy_switch/identy_switch_rpc.php';
 require_once INSTALL_PATH.'plugins/identy_switch/identy_switch_prefs.php';


### PR DESCRIPTION
The Roundcube installation directory is *two* levels up from the identy_switch plugin directory, not one.