### PR TITLE
Validate the request token in identity-switch actions (CSRF, #89)

### DIFF
--- a/identity_switch.php
+++ b/identity_switch.php
@@ -424,6 +424,16 @@ class identity_switch extends identity_switch_cfg
 	 */
 	function switch_identity(): void
 	{
+		$rc = rcmail::get_instance();
+
+		// Reject cross-site requests: this action changes session state
+		// ($_SESSION['username']/['password']), so the request token must be
+		// validated. The plugin's own JS sends it via rcmail.http_post().
+		if (!$rc->check_request()) {
+			$rc->output->show_message('invalidrequest', 'error');
+			return;
+		}
+
         // get new identity
         $iid = (int)rcube_utils::get_input_value('identity_switch_iid', rcube_utils::INPUT_POST);
 		// activate identity
@@ -446,6 +456,14 @@ class identity_switch extends identity_switch_cfg
 	function check_newmail()
 	{
 		$rc = rcmail::get_instance();
+
+		// Reject cross-site requests: this action switches the active identity
+		// and opens a server-side IMAP connection, so validate the request token.
+		// The plugin's own JS sends it via rcmail.http_post().
+		if (!$rc->check_request()) {
+			$rc->output->show_message('invalidrequest', 'error');
+			return;
+		}
 
 		// get iid to check
 		$iid = (int)rcube_utils::get_input_value('identity_switch_iid', rcube_utils::INPUT_POST);


### PR DESCRIPTION
Fixes the CSRF reported in #89.

`switch_identity()` and `check_newmail()` are registered plugin actions that change session state (`$_SESSION['username']`/`['password']`) and open a server-side IMAP connection, but they never validate Roundcube's request token.

Moving the client side to Ajax does not by itself prevent CSRF: `rcmail.http_post()` *sends* the `_token`, but the **server handler must still validate it** with `$rcmail->check_request()` — Roundcube does not auto-validate the token for plugin-registered actions (core write-actions and plugins like managesieve/password call `check_request()` explicitly). Without that check, an attacker page can auto-submit a cross-site POST to `?_task=mail&_action=plugin.identity_switch_run` and force an identity switch (and repeated IMAP connects via `identity_switch_newmail`).

This PR adds a `check_request()` guard at the top of both handlers. Because the plugin's own JS already sends the token via `rcmail.http_post()`, legitimate use is unaffected; only tokenless cross-site requests are rejected.

Tested: applied to a live Roundcube 1.7.2 instance with the plugin enabled — it loads and works normally; `php -l` clean.
